### PR TITLE
Allow exporting to a file within mjCmdlineScoring

### DIFF
--- a/mjcommon/scoreCalcs.cs
+++ b/mjcommon/scoreCalcs.cs
@@ -56,6 +56,7 @@ namespace RaceBeam
 		public bool showRookie;			// Applies to raw/pax/class
 		public bool writeCSV;
 		public string title;
+		public string outFile;
 		public scoreArgs()
 		{
 			eventFolder = "";
@@ -77,6 +78,7 @@ namespace RaceBeam
 			showRookie = false;
 			writeCSV = false;
 			title = "";
+			outFile = string.Empty;
 		}
 		// copy constructor
 		public scoreArgs(scoreArgs src)

--- a/mjscore/mjCmdlineScore.cs
+++ b/mjscore/mjCmdlineScore.cs
@@ -24,7 +24,7 @@ namespace RaceBeam
 		// ---------------------------------------------------------------------------
 		public static void Usage()
 		{
-			Console.WriteLine("Usage: mjCmdLineScore -day1 <day1 date> -day2 <day2 date> -bestsinglerun -set1only -set2only -runtimes -rawtimes -paxtimes -teams -conecounts -classtimes -rookie -maxofficialruns <# runs> -classfile <path to class.csv file> -title <string> -path <path to event data folder>");
+			Console.WriteLine("Usage: mjCmdLineScore -day1 <day1 date> -day2 <day2 date> -bestsinglerun -set1only -set2only -runtimes -rawtimes -paxtimes -teams -conecounts -classtimes -rookie -maxofficialruns <# runs> -classfile <path to class.csv file> -title <string> -path <path to event data folder> -out <file to write to>");
 			Environment.Exit(0);
 		}
 		// ---------------------------------------------------------------------------
@@ -36,6 +36,7 @@ namespace RaceBeam
             {
                 eventFolder = "."  // default to current folder
             };
+
             for (int i = 0; i < args.Length; i++)
 			{
 				if ((args[i] == "-h") | (args[i] == "-help") | (args[i] == "-?"))
@@ -127,6 +128,11 @@ namespace RaceBeam
 						argblock.maxOfficialRuns = 999;
 					}
 				}
+				else if (args[i] == "-out")
+                {
+					i += 1;
+					argblock.outFile = args[i];
+                }
 				else
 				{
 					Usage();
@@ -150,7 +156,17 @@ namespace RaceBeam
 			}
 			argblock.writeCSV = true;
 			results += textScores.textScore(argblock);
-			File.WriteAllText("./results.txt", results);
+
+			if (!string.IsNullOrEmpty(argblock.outFile))
+            {
+				File.WriteAllText(argblock.outFile, results);
+				Console.WriteLine("Results written to %s", argblock.outFile);
+            }
+            else
+            {
+				Console.WriteLine(results);
+			}
+
 			return;
 		}
 	}

--- a/mjscore/mjCmdlineScore.cs
+++ b/mjscore/mjCmdlineScore.cs
@@ -30,14 +30,14 @@ namespace RaceBeam
 		// ---------------------------------------------------------------------------
 		public static void Main(string[] args)
 		{
-            // parse command line arguments
-            // default to 1 day scoring, today's date
-            var argblock = new scoreArgs
-            {
-                eventFolder = "."  // default to current folder
-            };
+			// parse command line arguments
+			// default to 1 day scoring, today's date
+			var argblock = new scoreArgs
+			{
+				eventFolder = "."  // default to current folder
+			};
 
-            for (int i = 0; i < args.Length; i++)
+			for (int i = 0; i < args.Length; i++)
 			{
 				if ((args[i] == "-h") | (args[i] == "-help") | (args[i] == "-?"))
 				{
@@ -129,10 +129,10 @@ namespace RaceBeam
 					}
 				}
 				else if (args[i] == "-out")
-                {
+				{
 					i += 1;
 					argblock.outFile = args[i];
-                }
+				}
 				else
 				{
 					Usage();
@@ -158,12 +158,12 @@ namespace RaceBeam
 			results += textScores.textScore(argblock);
 
 			if (!string.IsNullOrEmpty(argblock.outFile))
-            {
+			{
 				File.WriteAllText(argblock.outFile, results);
 				Console.WriteLine("Results written to %s", argblock.outFile);
-            }
-            else
-            {
+			}
+			else
+			{
 				Console.WriteLine(results);
 			}
 

--- a/mjscore/mjCmdlineScore.cs
+++ b/mjscore/mjCmdlineScore.cs
@@ -150,7 +150,7 @@ namespace RaceBeam
 			}
 			argblock.writeCSV = true;
 			results += textScores.textScore(argblock);
-			Console.WriteLine(results);
+			File.WriteAllText("./results.txt", results);
 			return;
 		}
 	}

--- a/mjtiming/mjtiming_MainForm.cs
+++ b/mjtiming/mjtiming_MainForm.cs
@@ -913,12 +913,12 @@ namespace RaceBeam
 					string cmdfileName;
 					if (Day2TextBox.Text != "")
 					{
-						cmd += " > " + args.day2 + "__2-day" + "__scores.txt";
+						cmd += " -out " + args.day2 + "__2-day" + "__scores.txt";
 						cmdfileName = eventFolder + "\\" + args.day2 + "_2-day" + "__scoreCMD.bat";
 					}
 					else
 					{
-						cmd += " > " + args.day1 + "__scores.txt";
+						cmd += " -out " + args.day1 + "__scores.txt";
 						cmdfileName =   eventFolder + "\\" + args.day1 + "__scoreCMD.bat";
 					}
 					try


### PR DESCRIPTION
By default, Command Prompt on Windows (cmd.exe) will use [code page 437](https://en.wikipedia.org/wiki/Code_page_437), which causes UTF-8 characters to be interpreted and rendered as different font glyphs than intended when printing to the console.

To solve this, mjCmdlineScoring can instead export to a file which allows preserving UTF-8 encoding throughout.